### PR TITLE
Add migration to add new id column

### DIFF
--- a/lambda/src/main/resources/db/migration/V6__transfer_agreement_primary_key.sql
+++ b/lambda/src/main/resources/db/migration/V6__transfer_agreement_primary_key.sql
@@ -1,0 +1,5 @@
+ALTER TABLE TransferAgreement DROP FOREIGN KEY ConsignmentId;
+ALTER TABLE TransferAgreement DROP PRIMARY KEY;
+ALTER TABLE TransferAgreement ADD TransferAgreementId bigint(20) NOT NULL AUTO_INCREMENT PRIMARY KEY;
+ALTER TABLE TransferAgreement ADD KEY Consignment_Id_fkey (ConsignmentId);
+ALTER TABLE TransferAgreement ADD CONSTRAINT Consignment_Id_fkey FOREIGN KEY (ConsignmentId) REFERENCES Consignment (ConsignmentId);


### PR DESCRIPTION
TransferAgreementId column added as auto-increment and as new primary key

ConsignmentId changed to foreign constraint key

MySql requires primary keys to be auto incremented to enable returning value when inserting: https://scala-slick.org/doc/3.1.1/queries.html#inserting