### PR TITLE
Parameterize database port

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,13 @@
-## Consigment API Database Migrations
+# Consignment API data
+
+This project is part of [Transfer Digital Records][tdr]. It provides tools for working with the consignment database:
+
+* Database migrations
+* Scala code generation
+
+[tdr]: https://github.com/nationalarchives/tdr-dev-documentation
+
+## Database Migrations
 
 ### Adding a migration script
 
@@ -7,3 +16,14 @@
     * Run a lambda which updates the database within that environment.
     * Use slick codegen to generate slick files based on the database schema.
     * Deploy this code to Sonatype Nexus.
+
+## Code generation
+
+The project uses slick-codegen to generate [Slick] classes based on the database structure
+
+To generate code locally based on the current state of your local database, run `sbt slickCodegen`.
+
+To publish a new version of the consignment-api-db library containing the generated code, build the "TDR Graphql Code
+Generation" Jenkins job.
+
+[Slick]: http://scala-slick.org/

--- a/build.sbt
+++ b/build.sbt
@@ -54,7 +54,8 @@ releaseProcess := Seq[ReleaseStep](
   pushChanges
 )
 
-lazy val databaseUrl = "jdbc:mysql://localhost:3306/consignmentapi"
+lazy val databasePort = sys.env.getOrElse("DB_PORT", "3306")
+lazy val databaseUrl = s"jdbc:mysql://localhost:$databasePort/consignmentapi"
 lazy val databaseUser = "root"
 lazy val databasePassword = "password"
 
@@ -108,9 +109,8 @@ lazy val lambda = (project in file("lambda"))
 
 enablePlugins(FlywayPlugin)
 
-flywayUrl := "jdbc:mysql://localhost:3306/consignmentapi"
+flywayUrl := s"jdbc:mysql://localhost:$databasePort/consignmentapi"
 flywayUser := "root"
 flywayPassword := "password"
 flywayLocations += "filesystem:lambda/src/main/resources/db/migration"
 flywaySchemas += "consignmentapi"
-


### PR DESCRIPTION
Some developers are already running MySQL natively on their machines for another project. This will allow them to run a Dockerized MySQL on a different port.

Also add links and code generation instructions to README.