### PR TITLE
Migration to add auto increment column

### DIFF
--- a/lambda/src/main/resources/db/migration/V8__client_file_metadata_primary_key.sql
+++ b/lambda/src/main/resources/db/migration/V8__client_file_metadata_primary_key.sql
@@ -1,0 +1,6 @@
+ALTER TABLE ClientFileMetadata DROP FOREIGN KEY ClientFileMetadata_ibfk_1;
+ALTER TABLE ClientFileMetadata MODIFY COLUMN FileId bigint(20) NOT NULL;
+ALTER TABLE ClientFileMetadata DROP PRIMARY KEY;
+ALTER TABLE ClientFileMetadata ADD ClientFileMetadataId bigint(20) NOT NULL auto_increment PRIMARY KEY;
+ALTER TABLE ClientFileMetadata ADD KEY File_Id_fkey (FileId);
+ALTER TABLE ClientFileMetadata ADD CONSTRAINT File_Id_fkey FOREIGN KEY (FileId) REFERENCES File (FileId);


### PR DESCRIPTION
MySql requires primary key to be auto increment field

As FileId column is a foreign key constraint coming from the File table it is
not suitable as the primary key as it cannot be auto increment as the
value comes from another table

Add new column to be the primary key and make this auto increment

Reinstate FileId as a foreign key constraint

Following similar approach for the TransferAgreement table