### PR TITLE
Fix migration to make antivirus fields non-null

### DIFF
--- a/lambda/src/main/resources/db/migration/V9__make_antivirus_fields_mandatory.sql
+++ b/lambda/src/main/resources/db/migration/V9__make_antivirus_fields_mandatory.sql
@@ -1,3 +1,19 @@
+-- Add placeholders for missing data. This is safe because values should only
+-- be null for test data that was added manually.
+UPDATE "AVMetadata"
+  SET "Software" = 'PLACEHOLDER_SOFTWARE'
+  WHERE "Software" IS NULL;
+UPDATE "AVMetadata"
+  SET "SoftwareVersion" = 'PLACEHOLDER_SOFTWARE_VERSION'
+  WHERE "SoftwareVersion" IS NULL;
+UPDATE "AVMetadata"
+  SET "DatabaseVersion" = 'PLACEHOLDER_DATABASE_VERSION'
+  WHERE "DatabaseVersion" IS NULL;
+UPDATE "AVMetadata"
+  SET "Result" = 'PLACEHOLDER_RESULT'
+  WHERE "Result" IS NULL;
+
+-- Make fields non-null
 ALTER TABLE "AVMetadata"
   ALTER COLUMN "Software" SET NOT NULL,
   ALTER COLUMN "SoftwareVersion" SET NOT NULL,


### PR DESCRIPTION
The migration failed in integration because some of the rows had null antivirus data. This is probably because of test data, so it should be safe to insert placeholder values into those fields.