### PR TITLE
Add a delay before running the end-to-end tests

### DIFF
--- a/Jenkinsfile-run-migrations
+++ b/Jenkinsfile-run-migrations
@@ -30,7 +30,11 @@ pipeline {
       success {
         script {
           if (params.STAGE == "intg"){
-            tdr.runEndToEndTests(0, params.STAGE, BUILD_URL)
+            // Wait for a few minutes so the lambda has finished running before
+            // starting the end-to-end tests
+            def endToEndTestDelaySeconds = 180
+
+            tdr.runEndToEndTests(endToEndTestDelaySeconds, params.STAGE, BUILD_URL)
           }
         }
       }


### PR DESCRIPTION
The Jenkinsfile which runs the migrations just triggers the migrations lambda - it doesn't wait for the lambda to finish. So we need to add a delay before running the end-to-end tests, to make it more likely that the migration has finished before the e2e tests start.