### PR TITLE
Add migration to delete "Value" column from antivirus metadata

### DIFF
--- a/lambda/src/main/resources/db/migration/V10__delete_antivirus_value_column.sql
+++ b/lambda/src/main/resources/db/migration/V10__delete_antivirus_value_column.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "AVMetadata"
+  DROP COLUMN "Value";


### PR DESCRIPTION
This column was not used. The result of the antivirus scan is stored in the "Result" column.

The API does not save any data to this column, so it's safe to delete.

We'll have to be careful when releasing this, because the API uses the generated DB library which does reference the `Value` column, even though it just tries to save nulls to it. Release steps:

- [ ] Merge this PR
- [ ] Release a new version of the generated DB classes
- [ ] Update the consignment API to use latest version of the generated classes
- [ ] Deploy the consignment API
- [ ] Run the DB migrations