### PR TITLE
Only use the Scala Jenkins agent for the Flyway step of library deploment

### DIFF
--- a/Jenkinsfile-publish-library
+++ b/Jenkinsfile-publish-library
@@ -3,49 +3,49 @@ library("tdr-jenkinslib")
 def versionBumpBranch = "version-bump-${BUILD_NUMBER}"
 
 pipeline {
-    agent {
-      ecs {
-        inheritFrom "base"
-        taskDefinitionOverride "arn:aws:ecs:eu-west-2:${env.MANAGEMENT_ACCOUNT}:task-definition/s3publish-${params.STAGE}:2"
-      }
+  agent {
+    ecs {
+      inheritFrom "base"
+      taskDefinitionOverride "arn:aws:ecs:eu-west-2:${env.MANAGEMENT_ACCOUNT}:task-definition/s3publish-${params.STAGE}:2"
     }
-    stages {
-      stage("Create and push version bump GitHub branch") {
-        steps {
-          script {
-            tdr.configureJenkinsGitUser()
-          }
-
-          sh "git checkout -b ${versionBumpBranch}"
-
-          //sbt release requires branch to be on origin first
-          script {
-            tdr.pushGitHubBranch(versionBumpBranch)
-          }
+  }
+  stages {
+    stage("Create and push version bump GitHub branch") {
+      steps {
+        script {
+          tdr.configureJenkinsGitUser()
         }
-      }
-      stage("Publish to S3") {
-        steps {
-          sshagent(['github-jenkins']) {
-            sh "sbt flywayMigrate slickCodegen 'release with-defaults'"
-          }
-          script {
-            tdr.postToDaTdrSlackChannel(colour: "good", message: "*Database schema* :arrow_up: The database package has been published")
-          }
-        }
-      }
-      stage("Create version bump pull request") {
-        steps {
-          script {
-            tdr.createGitHubPullRequest(
-              pullRequestTitle: "Version Bump from build number ${BUILD_NUMBER}",
-              buildUrl: env.BUILD_URL,
-              repo: "tdr-consignment-api-data",
-              branchToMergeTo: "master",
-              branchToMerge: versionBumpBranch
-            )
-          }
+
+        sh "git checkout -b ${versionBumpBranch}"
+
+        //sbt release requires branch to be on origin first
+        script {
+          tdr.pushGitHubBranch(versionBumpBranch)
         }
       }
     }
+    stage("Publish to S3") {
+      steps {
+        sshagent(['github-jenkins']) {
+          sh "sbt flywayMigrate slickCodegen 'release with-defaults'"
+        }
+        script {
+          tdr.postToDaTdrSlackChannel(colour: "good", message: "*Database schema* :arrow_up: The database package has been published")
+        }
+      }
+    }
+    stage("Create version bump pull request") {
+      steps {
+        script {
+          tdr.createGitHubPullRequest(
+            pullRequestTitle: "Version Bump from build number ${BUILD_NUMBER}",
+            buildUrl: env.BUILD_URL,
+            repo: "tdr-consignment-api-data",
+            branchToMergeTo: "master",
+            branchToMerge: versionBumpBranch
+          )
+        }
+      }
+    }
+  }
 }

--- a/Jenkinsfile-publish-library
+++ b/Jenkinsfile-publish-library
@@ -4,10 +4,7 @@ def versionBumpBranch = "version-bump-${BUILD_NUMBER}"
 
 pipeline {
   agent {
-    ecs {
-      inheritFrom "base"
-      taskDefinitionOverride "arn:aws:ecs:eu-west-2:${env.MANAGEMENT_ACCOUNT}:task-definition/s3publish-${params.STAGE}:2"
-    }
+    label "master"
   }
   stages {
     stage("Create and push version bump GitHub branch") {
@@ -25,6 +22,12 @@ pipeline {
       }
     }
     stage("Publish to S3") {
+      agent {
+        ecs {
+          inheritFrom "base"
+          taskDefinitionOverride "arn:aws:ecs:eu-west-2:${env.MANAGEMENT_ACCOUNT}:task-definition/s3publish-${params.STAGE}:2"
+        }
+      }
       steps {
         sshagent(['github-jenkins']) {
           sh "sbt flywayMigrate slickCodegen 'release with-defaults'"


### PR DESCRIPTION
Use the default Jenkins node for the other steps.

This seems to fix a confusing bug where the Scala ECS task was not being started if it was used as the default agent for the pipeline.

Also fix the indentation, so this PR is probably easiest to review commit-by-commit.