### PR TITLE
Fix name of ECS task used to publish library to S3

### DIFF
--- a/Jenkinsfile-publish-library
+++ b/Jenkinsfile-publish-library
@@ -3,49 +3,49 @@ library("tdr-jenkinslib")
 def versionBumpBranch = "version-bump-${BUILD_NUMBER}"
 
 pipeline {
-    agent {
-      ecs {
-        inheritFrom "base"
-        taskDefinitionOverride "arn:aws:ecs:eu-west-2:${env.MANAGEMENT_ACCOUNT}:task-definition/s3publish-${params.STAGE}:2"
-      }
+  agent {
+    ecs {
+      inheritFrom "base"
+      taskDefinitionOverride "arn:aws:ecs:eu-west-2:${env.MANAGEMENT_ACCOUNT}:task-definition/s3publish-${params.STAGE}:2"
     }
-    stages {
-      stage("Create and push version bump GitHub branch") {
-        steps {
-          script {
-            tdr.configureJenkinsGitUser()
-          }
-
-          sh "git checkout -b ${versionBumpBranch}"
-
-          //sbt release requires branch to be on origin first
-          script {
-            tdr.pushGitHubBranch(versionBumpBranch)
-          }
+  }
+  stages {
+    stage("Create and push version bump GitHub branch") {
+      steps {
+        script {
+          tdr.configureJenkinsGitUser()
         }
-      }
-      stage("Publish to S3") {
-        steps {
-          sshagent(['github-jenkins']) {
-            sh "sbt flywayMigrate slickCodegen 'release with-defaults'"
-          }
-          script {
-            tdr.postToDaTdrSlackChannel(colour: "good", message: "*Database schema* :arrow_up: The database package has been published")
-          }
-        }
-      }
-      stage("Create version bump pull request") {
-        steps {
-          script {
-            tdr.createGitHubPullRequest(
-              pullRequestTitle: "Version Bump from build number ${BUILD_NUMBER}",
-              buildUrl: env.BUILD_URL,
-              repo: "tdr-consignment-api-data",
-              branchToMergeTo: "master",
-              branchToMerge: versionBumpBranch
-            )
-          }
+
+        sh "git checkout -b ${versionBumpBranch}"
+
+        //sbt release requires branch to be on origin first
+        script {
+          tdr.pushGitHubBranch(versionBumpBranch)
         }
       }
     }
+    stage("Publish to S3") {
+      steps {
+        sshagent(['github-jenkins']) {
+          sh "sbt flywayMigrate slickCodegen 'release with-defaults'"
+        }
+        script {
+          tdr.postToDaTdrSlackChannel(colour: "good", message: "*Database schema* :arrow_up: The database package has been published")
+        }
+      }
+    }
+    stage("Create version bump pull request") {
+      steps {
+        script {
+          tdr.createGitHubPullRequest(
+            pullRequestTitle: "Version Bump from build number ${BUILD_NUMBER}",
+            buildUrl: env.BUILD_URL,
+            repo: "tdr-consignment-api-data",
+            branchToMergeTo: "master",
+            branchToMerge: versionBumpBranch
+          )
+        }
+      }
+    }
+  }
 }

--- a/Jenkinsfile-publish-library
+++ b/Jenkinsfile-publish-library
@@ -6,7 +6,8 @@ pipeline {
   agent {
     ecs {
       inheritFrom "base"
-      taskDefinitionOverride "arn:aws:ecs:eu-west-2:${env.MANAGEMENT_ACCOUNT}:task-definition/s3publish-${params.STAGE}:2"
+      // Despite the name, the "s3publish-intg" task publishes the library to the TDR management account. See TDR-465.
+      taskDefinitionOverride "arn:aws:ecs:eu-west-2:${env.MANAGEMENT_ACCOUNT}:task-definition/s3publish-intg:2"
     }
   }
   stages {


### PR DESCRIPTION
The S3 publishing script needs to call the `s3publish-intg` ECS task to publish the library.

This step broke recently when we split up the Jenkinsfiles for deploying the migrations and publishing the library, because the `STAGE` parameter was omitted from Jenkinsfile-publish-library.

Hard-code the "intg" suffix for now. In future it should be removed altogether, because the library is published once to the management account, rather than separately to each TDR environment: https://national-archives.atlassian.net/browse/TDR-465

Also fix the indentation, so this PR is probably easiest to review commit-by-commit.