### PR TITLE
Remove the stage from the task definition.

### DIFF
--- a/Jenkinsfile-publish-library
+++ b/Jenkinsfile-publish-library
@@ -6,8 +6,7 @@ pipeline {
   agent {
     ecs {
       inheritFrom "base"
-      // Despite the name, the "s3publish-intg" task publishes the library to the TDR management account. See TDR-465.
-      taskDefinitionOverride "arn:aws:ecs:eu-west-2:${env.MANAGEMENT_ACCOUNT}:task-definition/s3publish-intg:2"
+      taskDefinitionOverride "arn:aws:ecs:eu-west-2:${env.MANAGEMENT_ACCOUNT}:task-definition/s3publish:2"
     }
   }
   stages {


### PR DESCRIPTION
The task definition s3Publish has been updated in the management account
so we don't need to use the old manually created task definition now.