### PR TITLE
Add the FileProperty entries for client side metadata

### DIFF
--- a/lambda/src/main/resources/db/migration/V15__add-client-side-properties-to-file-property.sql
+++ b/lambda/src/main/resources/db/migration/V15__add-client-side-properties-to-file-property.sql
@@ -1,0 +1,7 @@
+INSERT INTO "FileProperty" ("PropertyId", "Name", "Description", "Shortname")
+VALUES (uuid_generate_v4(), 'ClientSideOriginalFilepath', 'The originalfile path', 'ClientOriginalFilepath'),
+       (uuid_generate_v4(), 'ClientSideFileLastModifiedDate', 'The last modified date of the file',
+        'ClientFileLastModifiedDate'),
+       (uuid_generate_v4(), 'ClientSideFileSize', 'The size of the file', 'ClientFileSize'),
+       (uuid_generate_v4(), 'SHA256ClientSideChecksum', 'The sha256 checksum, generated on the client side',
+        'SHA256ClientChecksum');


### PR DESCRIPTION
I haven't moved the existing entries in yet. This will need doing when
the ClientFileMetadata table is deleted so there's no point doing it
now.
