### PR TITLE
Manually bump version

### DIFF
--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.0.35-SNAPSHOT"
+version in ThisBuild := "0.0.36-SNAPSHOT"


### PR DESCRIPTION
Manual bump required as versions got out of snyc following testing fix on separate branch using different Jenkins job

Once version is bumped will need to re-run the Migrations Publish Jenkins job to update the pg_dump.sql with the latest changes