### PR TITLE
Manually bump version to 0.0.38

### DIFF
--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.0.37-SNAPSHOT"
+version in ThisBuild := "0.0.38-SNAPSHOT"


### PR DESCRIPTION
Version 0.0.37 cannot be published because of some issues with the Jenkins build image.