### PR TITLE
Remove the hard coded version.

### DIFF
--- a/Jenkinsfile-publish-library
+++ b/Jenkinsfile-publish-library
@@ -6,7 +6,7 @@ pipeline {
   agent {
     ecs {
       inheritFrom "transfer-frontend"
-      taskDefinitionOverride "arn:aws:ecs:eu-west-2:${env.MANAGEMENT_ACCOUNT}:task-definition/s3publish:2"
+      taskDefinitionOverride "arn:aws:ecs:eu-west-2:${env.MANAGEMENT_ACCOUNT}:task-definition/s3publish"
     }
   }
   stages {


### PR DESCRIPTION
If you don't include a version, it just chooses the latest one.
