### PR TITLE
Make 'Name' primary key for 'ConsignmentProperty' table

### DIFF
--- a/lambda/src/main/resources/db/migration/V21__change_consignment_metata_foreign_key.sql
+++ b/lambda/src/main/resources/db/migration/V21__change_consignment_metata_foreign_key.sql
@@ -5,8 +5,7 @@ ALTER TABLE "ConsignmentMetadata" ADD CONSTRAINT
     "ConMetadata_PropertyName_fkey" FOREIGN KEY ("PropertyName") REFERENCES "ConsignmentProperty" ("Name")
         MATCH SIMPLE
         ON UPDATE NO ACTION
-        ON DELETE NO ACTION
-        NOT VALID;
+        ON DELETE NO ACTION;
 
 ALTER TABLE "ConsignmentProperty" DROP CONSTRAINT "ConProperty_pkey";
 ALTER TABLE "ConsignmentProperty" ADD CONSTRAINT "ConProperty_pkey" PRIMARY KEY ("Name");

--- a/lambda/src/main/resources/db/migration/V21__change_consignment_metata_foreign_key.sql
+++ b/lambda/src/main/resources/db/migration/V21__change_consignment_metata_foreign_key.sql
@@ -1,0 +1,13 @@
+ALTER TABLE "ConsignmentMetadata" DROP CONSTRAINT "ConMetadata_Property_fkey";
+ALTER TABLE "ConsignmentMetadata" ALTER COLUMN "PropertyId" TYPE text;
+ALTER TABLE "ConsignmentMetadata" RENAME COLUMN "PropertyId" TO "PropertyName";
+ALTER TABLE "ConsignmentMetadata" ADD CONSTRAINT
+    "ConMetadata_PropertyName_fkey" FOREIGN KEY ("PropertyName") REFERENCES "ConsignmentProperty" ("Name")
+        MATCH SIMPLE
+        ON UPDATE NO ACTION
+        ON DELETE NO ACTION
+        NOT VALID;
+
+ALTER TABLE "ConsignmentProperty" DROP CONSTRAINT "ConProperty_pkey";
+ALTER TABLE "ConsignmentProperty" ADD CONSTRAINT "ConProperty_pkey" PRIMARY KEY ("Name");
+ALTER TABLE "ConsignmentProperty" DROP COLUMN "PropertyId";


### PR DESCRIPTION
Unnecessary complexity was being caused by having the 'PropertyId' included in the 'ConsignmentMetadata' table as the property name was needed for the API

Decision to include the property name in the 'ConsignmentMetadata' table to remove complexity

'PropertyId' no longer required in the 'ConsignmentProperty' table as the property name is unique and can be used as the primary key in that table