### PR TITLE
Manual version bump

### DIFF
--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.0.42-SNAPSHOT"
+version in ThisBuild := "0.0.43-SNAPSHOT"


### PR DESCRIPTION
It looks like the versions are out of sync. version.sbt is on 42-SNAPSHOT but version 42 already exists so I'm manually bumping this to get us onto the next version.
