### PR TITLE
Change consignment sequence name to allow testing and production to work

### DIFF
--- a/lambda/src/main/resources/db/migration/V29__rename_consignment_seq.sql
+++ b/lambda/src/main/resources/db/migration/V29__rename_consignment_seq.sql
@@ -1,0 +1,3 @@
+-- Due to TDR having a different test DB to the real DB, we have had to convert the sequence name
+-- This means that the API will work in production, whilst allowing us to test the consignment API with a different test DB.
+ALTER SEQUENCE "ConsignmentSequenceID" RENAME TO consignment_sequence_id;


### PR DESCRIPTION
As we are using a H2 DB for testing and Postgres for production, some tests were failing due to the different DB interpretations of the same SQL lines. The simplest solution seems to be to change the consignment sequence object to lower_snake_case, to allow production and test DB's to work effectively.