### PR TITLE
Add `ConsignmentStatus` table with associated columns

### DIFF
--- a/lambda/src/main/resources/db/migration/V31__add_consignment_status_table.sql
+++ b/lambda/src/main/resources/db/migration/V31__add_consignment_status_table.sql
@@ -4,11 +4,8 @@ CREATE TABLE "ConsignmentStatus"
     "ConsignmentId" uuid NOT NULL,
     "StatusType" text NOT NULL,
     "Value" text NOT NULL,
-    "DateTime" timestamp with time zone not null,
+    "CreatedDatetime" timestamp with time zone not null,
     CONSTRAINT "ConsignmentStatus_pkey" PRIMARY KEY ("ConsignmentStatusId"),
     CONSTRAINT "ConsignmentStatus_Consignment_fkey" FOREIGN KEY ("ConsignmentId")
     REFERENCES "Consignment" ("ConsignmentId") MATCH SIMPLE
-    ON UPDATE NO ACTION
-    ON DELETE NO ACTION
-    NOT VALID
 )

--- a/lambda/src/main/resources/db/migration/V31__add_consignment_status_table.sql
+++ b/lambda/src/main/resources/db/migration/V31__add_consignment_status_table.sql
@@ -1,0 +1,14 @@
+CREATE TABLE "ConsignmentStatus"
+(
+    "ConsignmentStatusId" uuid NOT NULL,
+    "ConsignmentId" uuid NOT NULL,
+    "StatusType" text NOT NULL,
+    "Value" text NOT NULL,
+    "DateTime" timestamp with time zone not null,
+    CONSTRAINT "ConsignmentStatus_pkey" PRIMARY KEY ("ConsignmentStatusId"),
+    CONSTRAINT "ConsignmentStatus_Consignment_fkey" FOREIGN KEY ("ConsignmentId")
+    REFERENCES "Consignment" ("ConsignmentId") MATCH SIMPLE
+    ON UPDATE NO ACTION
+    ON DELETE NO ACTION
+    NOT VALID
+)


### PR DESCRIPTION
This will allow us to track the status of consignments in order to show the user an error if they try to upload a folder when an upload has already taken place.