### PR TITLE
Add ModifiedDateTime column and unique constraint to consignmentStatus table

### DIFF
--- a/lambda/src/main/resources/db/migration/V33__alter_consignment_status_table.sql
+++ b/lambda/src/main/resources/db/migration/V33__alter_consignment_status_table.sql
@@ -1,0 +1,3 @@
+ALTER TABLE "ConsignmentStatus"
+ADD "ModifiedDatetime" timestamp with time zone,
+ADD CONSTRAINT consignment_status UNIQUE ("ConsignmentId", "StatusType");


### PR DESCRIPTION
This will allow us to alter the use of the ConsignmentStatus table to have only _one_ row per consignment which gets altered when a consignment status is updated. This includes the constraint to ensure ConsignmentId and StatusType are always a unique combination.