### PR TITLE
TDR-1073 Remove default consignment sequence.

### DIFF
--- a/lambda/src/main/resources/db/migration/V34__remove_default_consignment_sequence.sql
+++ b/lambda/src/main/resources/db/migration/V34__remove_default_consignment_sequence.sql
@@ -1,2 +1,2 @@
 ALTER TABLE "Consignment" ALTER COLUMN "ConsignmentSequence" DROP DEFAULT;
-ALTER TABLE "Consignment" ALTER COLUMN "ConsignmentSequence" SET NOT NULL; 
+ALTER TABLE "Consignment" ALTER COLUMN "ConsignmentSequence" SET NOT NULL;

--- a/lambda/src/main/resources/db/migration/V34__remove_default_consignment_sequence.sql
+++ b/lambda/src/main/resources/db/migration/V34__remove_default_consignment_sequence.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "Consignment" ALTER COLUMN "ConsignmentSequence" DROP DEFAULT;
+ALTER TABLE "Consignment" ALTER COLUMN "ConsignmentSequence" SET NOT NULL; 


### PR DESCRIPTION
The consignment sequence is being incremented twice. It's being called with `select nextval('consignment_sequence_id')` and then it's being called again with the insert to the Consignment table.

If we want to keep the consignment reference mandatory, which we do, then the only option seems to be to remove the default. At no point are we inserting an empty value in here so we don't need the default.
