### PR TITLE
Added script to add new bodies and series plus some table alterations

### DIFF
--- a/lambda/src/main/resources/db/migration/V36__create_real_body_and_series.sql
+++ b/lambda/src/main/resources/db/migration/V36__create_real_body_and_series.sql
@@ -1,0 +1,40 @@
+DO $$ 
+DECLARE
+    bodyUuid "Body"."BodyId"%TYPE;
+BEGIN
+    
+    -- the Body Code column is no longer required
+    --rectify this
+    ALTER TABLE "Body" DROP COLUMN "Code";
+
+    -- I noticed that columns in the body table were nullable
+    --rectify this
+    ALTER TABLE "Body" ALTER COLUMN "Name" SET NOT NULL;
+    ALTER TABLE "Body" ALTER COLUMN "TdrCode" SET NOT NULL;
+
+    -- I noticed that columns in the series table were nullable
+    --rectify this
+    ALTER TABLE "Series" ALTER COLUMN "Name" SET NOT NULL;
+    ALTER TABLE "Series" ALTER COLUMN "Code" SET NOT NULL;
+
+    -- Insert in first body into the  Body Table
+    INSERT INTO "Body" ("BodyId", "Name", "Description", "TdrCode") VALUES
+      (uuid_generate_v4(), 'Welsh Government', 'Welsh Government', 'TDR-WA') RETURNING "BodyId" INTO bodyUuid;
+      
+    -- Use the returned bodyUuid value for the series insert
+    INSERT INTO "Series" ("SeriesId", "BodyId", "Code", "Name", "Description") VALUES
+      (uuid_generate_v4(), bodyUuid, 'WA 20', 'WA 20', 'WA 20');
+    
+    -- Insert in second body into the  Body Table
+    INSERT INTO "Body" ("BodyId", "Name", "Description", "TdrCode") VALUES
+      (uuid_generate_v4(), 'Ministry of Justice', 'Ministry of Justice', 'TDR-MOJ') RETURNING "BodyId" INTO bodyUuid;
+      
+    -- Use the returned bodyUuid value for the series insert
+    INSERT INTO "Series" ("SeriesId", "BodyId", "Code", "Name", "Description") VALUES
+      (uuid_generate_v4(), bodyUuid, 'LCO 72', 'LCO 72', 'LCO 72');
+
+
+END $$;
+
+--commit changes
+COMMIT; 


### PR DESCRIPTION
I've added the Body and Series using a Do script so that variables could be used to return the Body UUID to insert into the Series table. I also saw that some columns in both the body and series table were nullable which shouldn't really be. I have therefore corrected  this as part of the script. I also saw that the Body Code column still existed which should have been removed as part of an earlier update on the schema. I have removed the column as part of this as well. 