### PR TITLE
Replace task definition name

### DIFF
--- a/Jenkinsfile-publish-library
+++ b/Jenkinsfile-publish-library
@@ -6,7 +6,7 @@ pipeline {
   agent {
     ecs {
       inheritFrom "transfer-frontend"
-      taskDefinitionOverride "arn:aws:ecs:eu-west-2:${env.MANAGEMENT_ACCOUNT}:task-definition/s3publish"
+      taskDefinitionOverride "arn:aws:ecs:eu-west-2:${env.MANAGEMENT_ACCOUNT}:task-definition/sbtwithpostgres"
     }
   }
   stages {


### PR DESCRIPTION
The task name was changed a while ago to sbtwithpostgres.

The image hasn't been updated since then so we've not had any problems
but it has now so we need to change it to the image that's being managed
in terraform.
