### PR TITLE
Create a GitHub release for the lambda jar

### DIFF
--- a/Jenkinsfile-deploy-migrations
+++ b/Jenkinsfile-deploy-migrations
@@ -27,8 +27,7 @@ pipeline {
           sh "wget https://s3.amazonaws.com/rds-downloads/rds-ca-2019-root.pem"
         }
         sh "sbt lambda/assembly"
-        sh "mv lambda/target/scala-2.13/tdr-database*.jar lambda/target/scala-2.13/consignment.jar"
-        stash includes: "lambda/target/scala-2.13/consignment.jar", name: "consignment-jar"
+        stash includes: "lambda/target/scala-2.13/db-migrations.jar", name: "db-migrations.jar"
       }
     }
     stage("Deploy lambda") {
@@ -40,7 +39,7 @@ pipeline {
       }
       steps {
         script {
-          unstash "consignment-jar"
+          unstash "db-migrations.jar"
           def accountNumber = tdr.getAccountNumberFromStage(params.STAGE)
           sh "python3 /deploy_lambda.py ${accountNumber} ${params.STAGE} tdr-database-migrations-${params.STAGE} lambda/target/scala-2.13/consignment.jar"
           tdr.postToDaTdrSlackChannel(colour: "good", message: "*Database migrations* :arrow_up: The migration lambda has been deployed to *${params.STAGE}*")

--- a/Jenkinsfile-publish-library
+++ b/Jenkinsfile-publish-library
@@ -27,7 +27,9 @@ pipeline {
     stage("Publish to S3") {
       steps {
         sshagent(['github-jenkins']) {
-          sh "sbt flywayMigrate slickCodegen 'release with-defaults'"
+          withCredentials([string(credentialsId: 'github-jenkins-api-key', variable: 'GITHUB_TOKEN')]) {
+            sh "sbt flywayMigrate slickCodegen 'release with-defaults'"
+          }
         }
         script {
           tdr.postToDaTdrSlackChannel(colour: "good", message: "*Database schema* :arrow_up: The database package has been published")

--- a/Jenkinsfile-publish-library
+++ b/Jenkinsfile-publish-library
@@ -26,6 +26,9 @@ pipeline {
     }
     stage("Publish to S3") {
       steps {
+        dir("lambda/src/main/resources") {
+          sh "wget https://s3.amazonaws.com/rds-downloads/rds-ca-2019-root.pem"
+        }
         sshagent(['github-jenkins']) {
           withCredentials([string(credentialsId: 'github-jenkins-api-key', variable: 'GITHUB_TOKEN')]) {
             sh "sbt flywayMigrate slickCodegen 'release with-defaults'"

--- a/build.sbt
+++ b/build.sbt
@@ -87,7 +87,7 @@ lazy val root = (project in file("."))
     slickCodegenOutputDir := (scalaSource in Compile).value,
     ghreleaseRepoOrg := "nationalarchives",
     ghreleaseRepoName := "tdr-consignment-api-data",
-    ghreleaseAssets := Seq(file(s"${(lambda / assembly / target).value}/${(lambda /assembly / assemblyJarName).value}.tgz")),
+    ghreleaseAssets := Seq(file(s"${(lambda / assembly / target).value}/${(lambda /assembly / assemblyJarName).value}")),
     releaseProcess := Seq[ReleaseStep](
       inquireVersions,
       setReleaseVersion,

--- a/build.sbt
+++ b/build.sbt
@@ -1,8 +1,10 @@
 import com.github.tototoshi.sbt.slick.CodegenPlugin.autoImport.slickCodegenDatabaseUrl
 import sbt.Keys.libraryDependencies
 import ReleaseTransformations._
+import scala.sys.process._
 
-import java.nio.file.Files
+import java.nio.charset.StandardCharsets
+import java.nio.file.{Files, Paths}
 
 ThisBuild / scalaVersion     := "2.13.0"
 ThisBuild / version := (version in ThisBuild).value
@@ -35,7 +37,7 @@ ThisBuild / publishMavenStyle := true
 
 ThisBuild / publishTo := {
   val prefix = if (isSnapshot.value) "snapshots" else "releases"
-  Some(s3resolver.value(s"My ${prefix} S3 bucket", s3(s"tdr-$prefix-mgmt")))
+  Some(s3resolver.value(s"My $prefix S3 bucket", s3(s"tdr-$prefix-mgmt")))
 }
 
 val slickVersion = "3.3.2"
@@ -46,6 +48,21 @@ lazy val databaseUser = "tdr"
 lazy val databasePassword = "password"
 
 lazy val generateChangelogFile = taskKey[Unit]("Generates a changelog file from the last version")
+
+generateChangelogFile := {
+  val lastTag = "git describe --tags --abbrev=0".!!.replace("\n","")
+  val gitLog = s"git log $lastTag..HEAD --oneline".!!
+  val folderName = s"${baseDirectory.value}/notes"
+  val fileName = s"${version.value}.markdown"
+  val fullPath = s"$folderName/$fileName"
+  new File(folderName).mkdirs()
+  val file = new File(fullPath)
+  if(!file.exists()) {
+    new File(fullPath).createNewFile
+    Files.write(Paths.get(fullPath), gitLog.getBytes(StandardCharsets.UTF_8))
+  }
+  s"git add $fullPath".!!
+}
 
 resolvers +=
   "Sonatype OSS Snapshots" at "https://oss.sonatype.org/content/repositories/snapshots"
@@ -67,7 +84,24 @@ lazy val root = (project in file("."))
     slickCodegenJdbcDriver := "org.postgresql.Driver",
     slickCodegenOutputPackage := "uk.gov.nationalarchives",
     slickCodegenExcludedTables := Seq("schema_version"),
-    slickCodegenOutputDir := (scalaSource in Compile).value
+    slickCodegenOutputDir := (scalaSource in Compile).value,
+    ghreleaseRepoOrg := "nationalarchives",
+    ghreleaseRepoName := "tdr-consignment-api-data",
+    ghreleaseAssets := Seq(file(s"${(lambda / assembly / target).value}/${(lambda /assembly / assemblyJarName).value}.tgz")),
+    releaseProcess := Seq[ReleaseStep](
+      inquireVersions,
+      setReleaseVersion,
+      releaseStepTask(generateChangelogFile),
+      commitReleaseVersion,
+      tagRelease,
+      pushChanges,
+      releaseStepTask(assembly),
+      releaseStepInputTask(githubRelease),
+      publishArtifacts,
+      setNextVersion,
+      commitNextVersion,
+      pushChanges
+    ),
 
   ).enablePlugins(CodegenPlugin)
 
@@ -85,24 +119,7 @@ lazy val lambda = (project in file("lambda"))
         case PathList("META-INF", xs @ _*) => MergeStrategy.discard
         case _ => MergeStrategy.first
       },
-      assemblyJarName in assembly := "db-migrations.jar",
-      ghreleaseRepoOrg := "nationalarchives",
-      ghreleaseRepoName := "tdr-consignment-api-data",
-      ghreleaseAssets := Seq(file(s"${(target in assembly).value}/${(assembly / assemblyJarName).value}.tgz")),
-      releaseProcess := Seq[ReleaseStep](
-        inquireVersions,
-        setReleaseVersion,
-        releaseStepTask(generateChangelogFile),
-        commitReleaseVersion,
-        tagRelease,
-        pushChanges,
-        releaseStepTask(assembly),
-        releaseStepInputTask(githubRelease),
-        publishArtifacts,
-        setNextVersion,
-        commitNextVersion,
-        pushChanges
-      ),
+      assemblyJarName in assembly := "db-migrations.jar"
     )
 
 enablePlugins(FlywayPlugin)

--- a/notes/0.0.57.markdown
+++ b/notes/0.0.57.markdown
@@ -1,0 +1,2 @@
+ce806f8 MOve the custom release to the root project.
+773cb6c Setting version to 0.0.57-SNAPSHOT

--- a/notes/0.0.58.markdown
+++ b/notes/0.0.58.markdown
@@ -1,0 +1,2 @@
+430407f Manually bump version.sbt
+49aa59d Remove the tgz extension

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -3,9 +3,11 @@ addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "1.0.0")
 addSbtPlugin("io.github.davidmweber" % "flyway-sbt" % "6.1.4")
 libraryDependencies ++= Seq(
   "javax.xml.bind" % "jaxb-api" % "2.4.0-b180830.0359",
-  "org.postgresql" % "postgresql" % "42.2.11"
+  "org.postgresql" % "postgresql" % "42.2.11",
+  "com.sun.activation" % "javax.activation" % "1.2.0"
 )
 addSbtPlugin("com.github.tototoshi" % "sbt-slick-codegen" % "1.4.0")
 addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.13")
 resolvers += Resolver.jcenterRepo
 addSbtPlugin("ohnosequences" % "sbt-s3-resolver" % "0.19.0")
+addSbtPlugin("ohnosequences" % "sbt-github-release" % "0.7.0")

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.0.55-SNAPSHOT"
+version in ThisBuild := "0.0.55"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.0.57"
+version in ThisBuild := "0.0.58-SNAPSHOT"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.0.58"
+version in ThisBuild := "0.0.59-SNAPSHOT"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.0.56-SNAPSHOT"
+version in ThisBuild := "0.0.56"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.0.58-SNAPSHOT"
+version in ThisBuild := "0.0.58"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.0.57-SNAPSHOT"
+version in ThisBuild := "0.0.57"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.0.56"
+version in ThisBuild := "0.0.57-SNAPSHOT"


### PR DESCRIPTION
The performance checks need a jar file for the lambda in Github releases. This modifies the existing S3 release process to release to GitHub as well. 
This copies the process from the export where changelog notes are generated from the commit log.

I've also made the assembly jar name static and updated the deploy job to work with this.