### PR TITLE
'ConsignmentType' required

### DIFF
--- a/lambda/src/main/resources/db/migration/V42__backfill_consignment_type.sql
+++ b/lambda/src/main/resources/db/migration/V42__backfill_consignment_type.sql
@@ -1,0 +1,10 @@
+-- Update old rows with ConsignmentType 'standard' to ensure no gaps in the data
+-- All old rows relate to consignments which are not 'judgments' as no judgments have been uploaded previously
+UPDATE "Consignment" SET "ConsignmentType" = 'standard' WHERE "ConsignmentType" IS NULL;
+
+COMMIT;
+
+-- Ensure ConsignmentType always added for future rows
+ALTER TABLE "Consignment" ALTER COLUMN "ConsignmentType" SET NOT NULL;
+
+COMMIT;


### PR DESCRIPTION
Backfill existing rows with 'ConsignmentType' standard as no judgment consignments will have been created prior

Ensures no gaps in the existing data