### PR TITLE
Ignore unchanged pg_dump.sql file

### DIFF
--- a/Jenkinsfile-publish-library
+++ b/Jenkinsfile-publish-library
@@ -44,7 +44,7 @@ pipeline {
         script {
           sh "pg_dump -s -d consignmentapi -U tdr -h localhost > src/main/resources/pg_dump.sql"
           sh "git add src/main/resources/pg_dump.sql"
-          sh "git commit -m 'Add the latest sql script'"
+          sh "git commit -m 'Add the latest sql script' || true"
           tdr.pushGitHubBranch(versionBumpBranch)
         }
       }


### PR DESCRIPTION
If the database migration doesn't change the pg_dump.sql file, if it's
only a data update for example, then git commit returns exit code 1
which fails the Jenkins build.

If there is nothing to commit that's fine so we can just ignore the
error message by adding || true.
