### PR TITLE
Don't tag the release.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -78,7 +78,6 @@ lazy val root = (project in file("."))
       setReleaseVersion,
       releaseStepTask(setLatestTagOutput),
       commitReleaseVersion,
-      tagRelease,
       pushChanges,
       releaseStepCommand("publishSigned"),
       releaseStepCommand("sonatypeBundleRelease"),


### PR DESCRIPTION
The lambda deploy job is tagging the release so this doesn't have to.
