### PR TITLE
Don't run the lambda deploy on a version bump PR.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,11 +1,12 @@
 name: TDR Tag and pre deploy
 on:
-  push:
-    branches:
-      - master
+  pull_request:
+    types:
+      - closed
 jobs:
   pre-deploy:
     uses: nationalarchives/tdr-github-actions/.github/workflows/lambda_build.yml@main
+    if: ${{ github.base_ref == 'master' && github.event.pull_request.merged == true && !contains(github.event.pull_request.labels.*.name, 'Version bump') }}
     with:
       repo-name: tdr-consignment-api-data
       artifact-name: db-migrations

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -56,6 +56,6 @@ jobs:
             git add src/main/resources/pg_dump.sql
             git commit -m 'Add the latest sql script' || true
             git push -u origin $BRANCH_NAME
-            gh pr create --fill
+            gh pr create --fill --label 'Version bump'
         env:
           GITHUB_TOKEN: ${{ secrets.WORKFLOW_PAT }}


### PR DESCRIPTION
When we publish the db utils, it creates a PR for the version bump. This
is currently triggering the lambda deploy.

This should add a version bump label on publish. The build job will only
run for PRs that don't have this label.
