### PR TITLE
Version bump PR.

### DIFF
--- a/src/main/resources/pg_dump.sql
+++ b/src/main/resources/pg_dump.sql
@@ -51,6 +51,21 @@ CREATE TABLE public."AVMetadata" (
 ALTER TABLE public."AVMetadata" OWNER TO tdr;
 
 --
+-- Name: AllowedPuids; Type: TABLE; Schema: public; Owner: tdr
+--
+
+CREATE TABLE public."AllowedPuids" (
+    "PUID" text NOT NULL,
+    "PUID Description" text NOT NULL,
+    "Created Date" timestamp with time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    "Modified Date" timestamp with time zone,
+    "ConsignmentType" text NOT NULL
+);
+
+
+ALTER TABLE public."AllowedPuids" OWNER TO tdr;
+
+--
 -- Name: Body; Type: TABLE; Schema: public; Owner: tdr
 --
 
@@ -132,6 +147,21 @@ CREATE TABLE public."ConsignmentStatus" (
 
 
 ALTER TABLE public."ConsignmentStatus" OWNER TO tdr;
+
+--
+-- Name: DisallowedPuids; Type: TABLE; Schema: public; Owner: tdr
+--
+
+CREATE TABLE public."DisallowedPuids" (
+    "PUID" text NOT NULL,
+    "PUID Description" text NOT NULL,
+    "Created Date" timestamp with time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    "Modified Date" timestamp with time zone,
+    "Reason" text NOT NULL
+);
+
+
+ALTER TABLE public."DisallowedPuids" OWNER TO tdr;
 
 --
 -- Name: FFIDMetadata; Type: TABLE; Schema: public; Owner: tdr

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "0.1.14-SNAPSHOT"
+ThisBuild / version := "0.1.15-SNAPSHOT"


### PR DESCRIPTION
This failed because the Version bump label didn't exist and now it won't
overwrite the existing version so I've manually created this to get the
build running again.

The existing 0.1.14 version will be a available for use.
