### PR TITLE
'Active' column added for disallowed puids

### DIFF
--- a/lambda/src/main/resources/db/migration/V66__DisallowedPuids_add_active_column.sql
+++ b/lambda/src/main/resources/db/migration/V66__DisallowedPuids_add_active_column.sql
@@ -1,0 +1,5 @@
+-- Add 'active' column to allow additional disallowed PUIDs, but ignore them until need to filter on them
+
+ALTER TABLE "DisallowedPuids" ADD COLUMN "Active" BOOLEAN NOT NULL DEFAULT TRUE;
+
+COMMIT;


### PR DESCRIPTION
Having 'Active' column wil let clients filter on whether to use the disallowed puid or not

At the moment TDR accepts certain puids but in the future will not. Can add these puids values to the table whilst still accepting files with that puid value