### PR TITLE
Add non judgment to disallowed list.

### DIFF
--- a/lambda/src/main/resources/db/migration/V70__add_non_judgment_format_to_disallowed.sql
+++ b/lambda/src/main/resources/db/migration/V70__add_non_judgment_format_to_disallowed.sql
@@ -1,0 +1,6 @@
+-- This allows us to filter out any non docx files for judgments
+INSERT INTO "DisallowedPuids" ("PUID","PUID Description","Reason", "Active")
+VALUES
+    ('nonJudgmentFormat', 'No specific identifier for non judgment', 'NonJudgmentFormat', true);
+
+COMMIT;


### PR DESCRIPTION
If a judgment user uploads a non docx file, they get a status of
`NonJudgmentFormat` which isn't allowed so needs to be added to the
disallowed table.
