### PR TITLE
Tdr 2276 title public to title closed

### DIFF
--- a/lambda/src/main/resources/db/migration/V72__TitlePublic_to_TitleClosed.sql
+++ b/lambda/src/main/resources/db/migration/V72__TitlePublic_to_TitleClosed.sql
@@ -1,5 +1,5 @@
 -- Update TitlePublic to TitleClosed in FileProperty and FilePropertyValues tables
--- Logic of  values in FilePropertyValues to be reversed 
+-- The logic of  values in FilePropertyValues to be reversed 
 -- Default value would be false
 
 -- TO VERIFY - Is there a need to update the Dependencies integer field?
@@ -10,8 +10,8 @@ SET "Name" = 'TitleClosed', "FullName" = 'Title Closed'
 WHERE "Name" = 'TitlePublic';
 
 
--- Update PropertyName, PropertyValue and Default in the
--- FilePropertyValues table
+-- Update PropertyName, PropertyValue and Default values in the
+-- FilePropertyValues table, ensuring 'False' is the default
 UPDATE public."FilePropertyValues"
 SET "PropertyName" = 'TitleClosed', 
     "PropertyValue" = 'False',

--- a/lambda/src/main/resources/db/migration/V72__TitlePublic_to_TitleClosed.sql
+++ b/lambda/src/main/resources/db/migration/V72__TitlePublic_to_TitleClosed.sql
@@ -1,13 +1,11 @@
 -- Change name TitlePublic to TitleClosed in FileProperty and FilePropertyValues tables
--- Default PropertyValue to be false.
+-- Flip the 'True' and 'False' PropertyValue content
+-- Set default PropertyValue to be 'False'.
 
--- Update Name and FullName in FileProperty table
 UPDATE public."FileProperty"
 SET "Name" = 'TitleClosed', "FullName" = 'Title Closed'
 WHERE "Name" = 'TitlePublic';
 
--- Update PropertyName, PropertyValue and Default values in the
--- FilePropertyValues table, ensuring 'False' is the default
 UPDATE public."FilePropertyValues"
 SET "PropertyName" = 'TitleClosed', 
     "PropertyValue" = 'False',

--- a/lambda/src/main/resources/db/migration/V72__TitlePublic_to_TitleClosed.sql
+++ b/lambda/src/main/resources/db/migration/V72__TitlePublic_to_TitleClosed.sql
@@ -1,14 +1,10 @@
--- Update TitlePublic to TitleClosed in FileProperty and FilePropertyValues tables
--- The logic of  values in FilePropertyValues to be reversed 
--- Default value would be false
-
--- TO VERIFY - Is there a need to update the Dependencies integer field?
+-- Change name TitlePublic to TitleClosed in FileProperty and FilePropertyValues tables
+-- Default PropertyValue to be false.
 
 -- Update Name and FullName in FileProperty table
 UPDATE public."FileProperty"
 SET "Name" = 'TitleClosed', "FullName" = 'Title Closed'
 WHERE "Name" = 'TitlePublic';
-
 
 -- Update PropertyName, PropertyValue and Default values in the
 -- FilePropertyValues table, ensuring 'False' is the default

--- a/lambda/src/main/resources/db/migration/V72__TitlePublic_to_TitleClosed.sql
+++ b/lambda/src/main/resources/db/migration/V72__TitlePublic_to_TitleClosed.sql
@@ -19,3 +19,4 @@ SET "PropertyName" = 'TitleClosed',
 WHERE "PropertyName" = 'TitlePublic' AND "PropertyValue" = 'False';
 
 COMMIT;
+ 

--- a/lambda/src/main/resources/db/migration/V72__TitlePublic_to_TitleClosed.sql
+++ b/lambda/src/main/resources/db/migration/V72__TitlePublic_to_TitleClosed.sql
@@ -19,4 +19,3 @@ SET "PropertyName" = 'TitleClosed',
 WHERE "PropertyName" = 'TitlePublic' AND "PropertyValue" = 'False';
 
 COMMIT;
- 

--- a/lambda/src/main/resources/db/migration/V72__TitlePublic_to_TitleClosed.sql
+++ b/lambda/src/main/resources/db/migration/V72__TitlePublic_to_TitleClosed.sql
@@ -1,0 +1,27 @@
+-- Update TitlePublic to TitleClosed in FileProperty and FilePropertyValues tables
+-- Logic of  values in FilePropertyValues to be reversed 
+-- Default value would be false
+
+-- TO VERIFY - Is there a need to update the Dependencies integer field?
+
+-- Update Name and FullName in FileProperty table
+UPDATE public."FileProperty"
+SET "Name" = 'TitleClosed', "FullName" = 'Title Closed'
+WHERE "Name" = 'TitlePublic';
+
+
+-- Update PropertyName, PropertyValue and Default in the
+-- FilePropertyValues table
+UPDATE public."FilePropertyValues"
+SET "PropertyName" = 'TitleClosed', 
+    "PropertyValue" = 'False',
+    "Default" = TRUE
+WHERE "PropertyName" = 'TitlePublic' AND "PropertyValue" = 'True';
+
+UPDATE public."FilePropertyValues"
+SET "PropertyName" = 'TitleClosed', 
+    "PropertyValue" = 'True',
+    "Default" = NULL
+WHERE "PropertyName" = 'TitlePublic' AND "PropertyValue" = 'False';
+
+COMMIT;

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "0.1.20-SNAPSHOT"
+ThisBuild / version := "0.1.18-SNAPSHOT"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "0.1.18-SNAPSHOT"
+ThisBuild / version := "0.1.20-SNAPSHOT"


### PR DESCRIPTION
- Change name 'TitlePublic' to 'TitleClosed' in FileProperty and FilePropertyValues tables
- Flip the 'True' and 'False' PropertyValue content to keep the logic correct.
- Set default PropertyValue to be 'False'.