### PR TITLE
Include META-INF services

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -98,6 +98,7 @@ lazy val lambda = (project in file("lambda"))
         "com.github.pureconfig" %% "pureconfig" % "0.17.1"
       ),
       (assembly / assemblyMergeStrategy) := {
+        case PathList("META-INF", "services", xs@_*) => MergeStrategy.first
         case PathList("META-INF", xs @ _*) => MergeStrategy.discard
         case _ => MergeStrategy.first
       },


### PR DESCRIPTION
Since the upgrade of flyway, it now needs a list of database plugins
which it gets from the META-INF services directory.

sbt assembly was discarding this, this line will keep it.
