### PR TITLE
Pin the publish job to postgres 14.

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     services:
       postgres:
-        image: postgres
+        image: postgres:14
         env:
           POSTGRES_PASSWORD: password
           POSTGRES_USER: tdr


### PR DESCRIPTION
The version of pg_dump on the GitHub runners is at 14 but the latest
postgres docker image is 15 and they aren't compatible.

RDS is running postgres 14 so we should be using that to publish for
consistency.
