### PR TITLE
TDR-2852 Update TitleAlternate description.

### DIFF
--- a/lambda/src/main/resources/db/migration/V104__update_display_properties_alternate_title.sql
+++ b/lambda/src/main/resources/db/migration/V104__update_display_properties_alternate_title.sql
@@ -3,4 +3,8 @@ SET "Value" = 'This title will be visible to the public during the closure perio
 WHERE "PropertyName" = 'TitleAlternate'
   AND "Attribute" = 'Description';
 
+INSERT INTO "DisplayProperties" ("PropertyName", "Attribute", "Value", "AttributeType")
+VALUES
+    ('DescriptionAlternate', 'Description', 'This description will be visible to the public during the closure period.', 'text');
+
 COMMIT;

--- a/lambda/src/main/resources/db/migration/V104__update_display_properties_alternate_title.sql
+++ b/lambda/src/main/resources/db/migration/V104__update_display_properties_alternate_title.sql
@@ -1,0 +1,6 @@
+UPDATE "DisplayProperties"
+SET "Value" = 'This title will be visible to the public during the closure period.'
+WHERE "PropertyName" = 'TitleAlternate'
+  AND "Attribute" = 'Description';
+
+COMMIT;


### PR DESCRIPTION
This ticket asks for hint text to be added to the AlternateTitle field.
In other places, we're using the description for hint text and it doesn't look like we're using the description for this field for anything at the moment so I think this is ok.

I'll update the frontend to use this on the page. https://github.com/nationalarchives/tdr-transfer-frontend/pull/2674
