### PR TITLE
TDR-2905 Add details summary and text.

### DIFF
--- a/lambda/src/main/resources/db/migration/v105__display_properties_description.sql
+++ b/lambda/src/main/resources/db/migration/v105__display_properties_description.sql
@@ -1,0 +1,12 @@
+-- Update the description value of the DisplayProperties and insert new details component text.
+
+UPDATE "DisplayProperties"
+SET "Value" = 'The description of this record will be visible to the public to help explain its content.'
+WHERE "PropertyName" = 'description' AND "Attribute" = 'Description';
+
+INSERT INTO "DisplayProperties" ("PropertyName", "Attribute", "Value", "AttributeType")
+VALUES
+    ('description', 'DetailsSummary', 'Is the description sensitive to the public?', 'text'),
+    ('description', 'DetailsText', 'If the description of this record contains sensitive information, you must enter the full uncensored version in this field. You can enter an alternative description on the Closure metadata page.', 'text');
+
+COMMIT;


### PR DESCRIPTION
This is to allow us to add text to a GDS details component.
Front end changes are here
https://github.com/nationalarchives/tdr-transfer-frontend/pull/2693

I've also updated the `description` Description to match the prototype.
