### PR TITLE
TDR-2586 use correct permissions

### DIFF
--- a/.github/scripts/create-user.sql
+++ b/.github/scripts/create-user.sql
@@ -1,0 +1,3 @@
+CREATE USER migrations_user WITH PASSWORD 'migrations_password';
+GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA public TO migrations_user;
+GRANT ALL PRIVILEGES ON ALL SEQUENCES IN SCHEMA public TO migrations_user;

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     services:
       postgres:
-        image: postgres
+        image: postgres:14
         env:
           POSTGRES_PASSWORD: password
           POSTGRES_USER: tdr
@@ -20,5 +20,7 @@ jobs:
           - 5432:5432
     steps:
       - uses: actions/checkout@v3
+      - name: Create migrations user
+        run: PGPASSWORD=password psql -U tdr -h localhost -d consignmentapi -f ./scripts/create-user.sql
       - name: Test
         run: sbt flywayMigrate

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,6 +21,6 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Create migrations user
-        run: PGPASSWORD=password psql -U tdr -h localhost -d consignmentapi -f ./scripts/create-user.sql
+        run: PGPASSWORD=password psql -U tdr -h localhost -d consignmentapi -f .github/scripts/create-user.sql
       - name: Test
         run: sbt flywayMigrate

--- a/build.sbt
+++ b/build.sbt
@@ -35,8 +35,8 @@ val slickVersion = "3.4.1"
 
 lazy val databasePort = sys.env.getOrElse("DB_PORT", "5432")
 lazy val databaseUrl = s"jdbc:postgresql://localhost:$databasePort/consignmentapi"
-lazy val databaseUser = "tdr"
-lazy val databasePassword = "password"
+lazy val databaseUser = "migrations_user"
+lazy val databasePassword = "migrations_password"
 
 lazy val setLatestTagOutput = taskKey[Unit]("Generates a changelog file from the last version")
 


### PR DESCRIPTION
Because the real migration uses the migrations_user and the test is running with admin permissions, we can have problems where the tests pass but the run in the lambda fails because of permissions issues.

This creates a user with the same permissions as the migrations user we use for production.