### PR TITLE
Run tests on master first

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,12 @@ jobs:
           - 5432:5432
     steps:
       - uses: actions/checkout@v3
+        with:
+          ref: 'master'
       - name: Create migrations user
         run: PGPASSWORD=password psql -U tdr -h localhost -d consignmentapi -f .github/scripts/create-user.sql
+      - name: Run migrate for master
+        run: sbt flywayMigrate
+      - uses: actions/checkout@v3
       - name: Test
         run: sbt flywayMigrate


### PR DESCRIPTION
The tests are run on a clean database which means if there are changes which break existing migrations, they won't be caught. This runs them on master first and then against the branch to try and catch these errors.