### PR TITLE
Create migrations_user in publish job

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -33,6 +33,7 @@ jobs:
       - name: Publish
         id: publish
         run: |
+            PGPASSWORD=password psql -U tdr -h localhost -d consignmentapi -f .github/scripts/create-user.sql
             git config --global user.email digitalpreservation@nationalarchives.gov.uk
             git config --global user.name tna-digital-archiving-jenkins
             git checkout -b $BRANCH_NAME


### PR DESCRIPTION
The user in the build.sbt file is migrations_user but it hasn't been
created inside the publish job. This is the same scripts the tests use
to this should work.
