### PR TITLE
Add 'Required' property to support UI

### DIFF
--- a/lambda/src/main/resources/db/migration/V107__Insert_displayproperties_data.sql
+++ b/lambda/src/main/resources/db/migration/V107__Insert_displayproperties_data.sql
@@ -1,0 +1,24 @@
+-- Insert data into the DisplayProperties table
+
+INSERT INTO "DisplayProperties" ("PropertyName","Attribute","Value","AttributeType") 
+VALUES
+  ('date_range','Required','false','boolean'),
+  ('Filename','Required','true','boolean'),
+  ('file_name_translation','Required','false','boolean'),
+  ('description','Required','false','boolean'),
+  ('DescriptionAlternate','Required','false','boolean'),
+  ('ClosurePeriod','Required','true','boolean'),
+  ('DescriptionClosed','Required','false','boolean'),
+  ('TitleAlternate','Required','false','boolean'),
+  ('TitleClosed','Required','true','boolean'),
+  ('FoiExemptionCode','Required','true','boolean'),
+  ('FoiExemptionAsserted','Required','true','boolean'),
+  ('end_date','Required','false','boolean'),
+  ('date_created','Required','false','boolean'),
+  ('start_date','Required','false','boolean'),
+  ('ClosureStartDate','Required','true','boolean'),
+  ('Language','Required','true','boolean'),
+  ('file_name_language','Required','false','boolean'),
+  ('file_name_translation_language','Required','false','boolean');
+
+COMMIT;


### PR DESCRIPTION
Decoupling whether a field is required in the UI from whether the data schema requires the field

There are instances where a field is not required in the data schema, but need to force the user to actively enter a value in the UI, for example 'ClosureStartDate' field