### PR TITLE
Backfill includeTopLevel folder flag.

### DIFF
--- a/lambda/src/main/resources/db/migration/V114__backfill-include-folder-flag.sql
+++ b/lambda/src/main/resources/db/migration/V114__backfill-include-folder-flag.sql
@@ -1,0 +1,6 @@
+UPDATE "Consignment"
+SET "IncludeTopLevelFolder" = false
+WHERE "IncludeTopLevelFolder" IS NULL
+  AND "ConsignmentType" = 'judgment';
+
+COMMIT;


### PR DESCRIPTION
This is only for the judgment users.
