### PR TITLE
TDR-635 Drop shortname from the ConsignmentProperty table

### DIFF
--- a/lambda/src/main/resources/db/migration/V118__drop_shortname_consignmentproperty.sql
+++ b/lambda/src/main/resources/db/migration/V118__drop_shortname_consignmentproperty.sql
@@ -1,0 +1,3 @@
+-- Drop column Shortname from the ConsignmentProperty table
+
+ALTER TABLE public."ConsignmentProperty" DROP COLUMN "Shortname";


### PR DESCRIPTION
Upon dropping the column, generating the slick classes and running through the whole upload process everything was still working.