### PR TITLE
TDR-3401 Add file extension "mismatch" and "format name" to the relevant DB table

### DIFF
--- a/lambda/src/main/resources/db/migration/V125__update_ffidmetadatamatches_to_include_mismatch_boolean_and_format_name.sql
+++ b/lambda/src/main/resources/db/migration/V125__update_ffidmetadatamatches_to_include_mismatch_boolean_and_format_name.sql
@@ -1,0 +1,3 @@
+ALTER TABLE "FFIDMetadataMatches"
+    ADD COLUMN ExtensionMismatch boolean NOT NULL DEFAULT false,
+    ADD COLUMN FormatName text NOT NULL;


### PR DESCRIPTION
[TDR-3401](https://national-archives.atlassian.net/browse/TDR-3401?atlOrigin=eyJpIjoiMWIyNDE1OWMxOWYxNDc0OWE0MWE0OTA0NzYyYzExODYiLCJwIjoiaiJ9)

- [x] Update FFIDMetadataMatches table to include ExtensionMismatch (bool), FormatName (text) columns as per ticket specification 