### PR TITLE
Enforce 'camel case' naming on columns

### DIFF
--- a/lambda/src/main/resources/db/migration/V127__fix_ffidmetadatamatches_mismatch_and_format_name.sql
+++ b/lambda/src/main/resources/db/migration/V127__fix_ffidmetadatamatches_mismatch_and_format_name.sql
@@ -1,0 +1,3 @@
+-- Enforce 'camel case' naming for columns
+ALTER TABLE "FFIDMetadataMatches" RENAME COLUMN "extensionmismatch" TO "ExtensionMismatch";
+ALTER TABLE "FFIDMetadataMatches" RENAME COLUMN "formatname" TO "FormatName";


### PR DESCRIPTION
Original migration (V126) did not double quote the column names so formatting was defaulted to lower casing

Naming convention for column names should be camel case