### PR TITLE
Run tests on pull request

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,6 @@
 name: TDR Run Flyway Test
 on:
+  pull_request:
   push:
 jobs:
   test:


### PR DESCRIPTION
The version bump pr's were stuck waiting for the checks because we only enabled checks for commits and not on pull requests. This adds this change.