### PR TITLE
TDR-3689 Add `UUID` to the FileProperty table

### DIFF
--- a/lambda/src/main/resources/db/migration/V145__add_file_uuid_to_fileproperty.sql
+++ b/lambda/src/main/resources/db/migration/V145__add_file_uuid_to_fileproperty.sql
@@ -1,0 +1,8 @@
+-- Add 'UUID' to FileProperty table
+-- 'UUID' refers to the 'FileID'
+
+INSERT INTO "FileProperty" ("Name", "Description", "FullName", "PropertyType", "Datatype", "Editable", "MultiValue",
+                            "PropertyGroup", "AllowExport", "ExportOrdinal")
+VALUES ('UUID', NULL, 'UUID', 'System', 'text', false, false, 'System', true, 150);
+
+COMMIT;


### PR DESCRIPTION
The value of UUID will be that of the FileId which will be included as part of the bagit export