### PR TITLE
Upgrade postgresql to version 17

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -55,6 +55,16 @@ jobs:
         with:
           message: "*Database schema* :arrow_up: The database package has been published"
           slack-url: ${{ secrets.SLACK_WEBHOOK }}
+      - name: Upgrade PG Dump
+        id: upgrade_pg_dump
+        run: |
+          sudo apt-get purge --auto-remove postgresql-14
+          sudo apt install curl ca-certificates
+          sudo install -d /usr/share/postgresql-common/pgdg
+          sudo curl -o /usr/share/postgresql-common/pgdg/apt.postgresql.org.asc --fail https://www.postgresql.org/media/keys/ACCC4CF8.asc
+          sudo sh -c 'echo "deb [signed-by=/usr/share/postgresql-common/pgdg/apt.postgresql.org.asc] https://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
+          sudo apt update
+          sudo apt install postgresql-17 -y
       - name: Publish new sql file
         run: |
             PGPASSWORD=password pg_dump -s -d consignmentapi -U tdr -h localhost > src/main/resources/pg_dump.sql

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "0.1.42-SNAPSHOT"
+ThisBuild / version := "0.1.44-SNAPSHOT"


### PR DESCRIPTION
By default ubuntu-latest Github action images ships with version 14 of postgresql

As DB has been upgraded to version 17 need this version of postgresql to run the 'pg_dump' command otherwise an incompatiblity error is thrown

Previous version requires purging first otherwise it still appears as the version used