### PR TITLE
[TDRD 1126] Add migration to populate metadata review confirmation actions for past transfers

### DIFF
--- a/lambda/src/main/resources/db/migration/V199__add_confirmation_entries_to_metadata_review_log.sql
+++ b/lambda/src/main/resources/db/migration/V199__add_confirmation_entries_to_metadata_review_log.sql
@@ -1,0 +1,16 @@
+INSERT INTO "MetadataReviewLog" ("MetadataReviewLogId", "ConsignmentId", "UserId", "Action", "EventTime")
+SELECT
+    gen_random_uuid(),
+    cs."ConsignmentId",
+    c."UserId",
+    'Confirmation',
+    cs."CreatedDatetime"
+FROM "ConsignmentStatus" cs
+         JOIN "Consignment" c ON c."ConsignmentId" = cs."ConsignmentId"
+WHERE cs."StatusType" = 'ConfirmTransfer'
+  AND cs."Value" = 'Completed'
+  AND EXISTS (
+    SELECT 1 FROM "MetadataReviewLog" mrl
+    WHERE mrl."ConsignmentId" = cs."ConsignmentId"
+      AND mrl."Action" = 'Approval'
+);

--- a/lambda/src/main/resources/db/migration/V199__add_confirmation_entries_to_metadata_review_log.sql
+++ b/lambda/src/main/resources/db/migration/V199__add_confirmation_entries_to_metadata_review_log.sql
@@ -13,4 +13,9 @@ WHERE cs."StatusType" = 'ConfirmTransfer'
     SELECT 1 FROM "MetadataReviewLog" mrl
     WHERE mrl."ConsignmentId" = cs."ConsignmentId"
       AND mrl."Action" = 'Approval'
+)
+  AND NOT EXISTS (
+    SELECT 1 FROM "MetadataReviewLog" mrl
+    WHERE mrl."ConsignmentId" = cs."ConsignmentId"
+      AND mrl."Action" = 'Confirmation'
 );


### PR DESCRIPTION
The logic I'm going for here is:
- **for all** consignments that have a "Completed" entry for the "ConfirmTransfer" stage in the ConsignmentStatus table
- **and** an "Approval" action in the MetadataReviewLog table
- **add** a "Confirmation" entry to the MetadataReviewLog table at the time confirm transfer was completed