### PR TITLE
Alter tables to include 'Asset Id' entries

### DIFF
--- a/lambda/src/main/resources/db/migration/V211__asset_id_support.sql
+++ b/lambda/src/main/resources/db/migration/V211__asset_id_support.sql
@@ -1,0 +1,8 @@
+-- Add 'AssetId' property to File table
+ALTER TABLE "File" ADD COLUMN "AssetId" uuid;
+
+-- Add 'AssetId' field to the FileProperty table
+INSERT INTO "FileProperty" ("Name", "Description", "FullName", "Datatype")
+    VALUES ('AssetId', 'Asset Id for the record', 'asset_id', 'text');
+
+COMMIT;


### PR DESCRIPTION
TDR needs to generate and persist the 'asset id' to ensure idempotency for DR2 systems